### PR TITLE
add dependency for parallel compilation

### DIFF
--- a/llvm/lib/Transforms/TestPass/CMakeLists.txt
+++ b/llvm/lib/Transforms/TestPass/CMakeLists.txt
@@ -2,6 +2,7 @@ add_llvm_library(LLVMTestPass MODULE BUILDTREE_ONLY
 	TestPass.cpp
 
 	DEPENDS
+	intrinsics_gen
 	PLUGIN_TOOL
 	opt
 	)


### PR DESCRIPTION
`make -j128` fails with the following error. TestPass has to depend on intrinsics_gen to support parallel compilation.

```
In file included from /home/seulbae/llvm-sanitizer-tutorial/llvm/include/llvm/IR/Argument.h:19:0,
                 from /home/seulbae/llvm-sanitizer-tutorial/llvm/include/llvm/IR/Function.h:26,
                 from /home/seulbae/llvm-sanitizer-tutorial/llvm/include/llvm/IR/PassManager.h:45,
                 from /home/seulbae/llvm-sanitizer-tutorial/llvm/include/llvm/Transforms/Instrumentation/TestSanitizer.h:4,
                 from /home/seulbae/llvm-sanitizer-tutorial/llvm/lib/Transforms/TestPass/TestPass.cpp:3:
/home/seulbae/llvm-sanitizer-tutorial/llvm/include/llvm/IR/Attributes.h:74:14: fatal error: llvm/IR/Attributes.inc: No such file or directory
     #include "llvm/IR/Attributes.inc"
              ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```